### PR TITLE
Showing how the text is only rendered in 6.7.10

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,14 +1,14 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
-import { useAuthUser, withFronteggApp } from "@frontegg/nextjs";
-import { useEffect } from "react";
+import { withFronteggApp } from "@frontegg/nextjs";
 
 function App({ Component, pageProps }: AppProps) {
-  useEffect(() => {
-    alert("I should not see this");
-  }, []);
-
-  return <Component {...pageProps} />;
+  return (
+    <>
+      I will only be rendered on 6.7.10
+      <Component {...pageProps} />
+    </>
+  );
 }
 
 export default withFronteggApp(App, { hostedLoginBox: false });


### PR DESCRIPTION
# Description

This branch shows the issue we have been seeing in our own app.

- On 6.7.4 the text will NOT be rendered before the login box
- on 6.7.10 the text will be rendered